### PR TITLE
Add "owners" field

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 data "aws_ami" "ec2-linux" {
   most_recent = true
+  owners      = ["amazon"]
 
   filter {
     name   = "name"


### PR DESCRIPTION
This adds the required owners filed in [terraform-aws-provider 2](https://www.terraform.io/docs/providers/aws/guides/version-2-upgrade.html). 

"**Owners Argument Now Required**
The owners argument is now required. Specifying owner-id or owner-alias under filter does not satisfy this requirement."