### PR TITLE
 Fix branch name in GHA workflow

### DIFF
--- a/.github/workflows/tf-validate.yml
+++ b/.github/workflows/tf-validate.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - master
   push: 
     branches-ignore:
       - 'main'
+      - 'master'
 
 # Set defaults
 defaults:


### PR DESCRIPTION

    [ N/A ] The README contains the correct list of dependencies, inputs, and outputs (e.g., terraform-docs markdown . has been run)

What does this PR do?

Adds "master" to the branches to be monitored by the GHA workflow
Helpful background context

Why these changes are being introduced:
The tf-mod-* modules are all still using "master" for the primary
branch instead of "main." This workflow did not include the "master"
branch in the filter.
What are the relevant tickets?

N/A
Requires Database Migrations?

NO
Includes new or updated dependencies?

NO